### PR TITLE
Fix selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,9 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 project(svfit)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_FLAGS "-fPIC -DDROP_CGAL -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-parameter")
+
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS "-fPIC -DDROP_CGAL -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-parameter")
 
+enable_testing()
+
 add_subdirectory(src)
+add_subdirectory(tests)

--- a/src/SVfitStandaloneQuantities.cc
+++ b/src/SVfitStandaloneQuantities.cc
@@ -12,6 +12,8 @@
 #include <TMatrixDSymEigen.h>
 #include <TVectorD.h>
 
+#include <numeric>
+
 namespace svFitStandalone
 {
   TH1* makeHistogram(const std::string& histogramName, double xMin, double xMax, double logBinWidth)

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -1,6 +1,6 @@
 <lcgdict>
     <selection>
-    <class name="SVfitStandaloneAlgorithm::SVfitStandaloneAlgorithm"/>
+    <class name="SVfitStandaloneAlgorithm"/>
     <class name="SVfitStandaloneAlgorithm::measuredTauLeptons"/>
     <!-- <class name="SVfitStandaloneAlgorithm::measuredTauLeptons"/>
     <class name="SVfitStandaloneAlgorithm::measuredTauLeptons"/>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+include(CTest)
+
+add_test(NAME import-test COMMAND python tests/import-test.py
+         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+set_property(TEST import-test PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH})
+

--- a/tests/import-test.py
+++ b/tests/import-test.py
@@ -1,0 +1,6 @@
+import ROOT
+ROOT.gSystem.Load("libSVfitStandaloneAlgorithm")
+from ROOT import SVfitStandaloneAlgorithm
+
+# more to follow
+


### PR DESCRIPTION
This PR proposes the following changes:

- selection.xml previously only imported the ctor, not the whole class `SVfitStandaloneAlgorithm`
- C++ standard was not properly declared in CmakeLists, now sets to c++14
- Missing `<numeric>` include for standalone compilation